### PR TITLE
hasProperty and removeProperty

### DIFF
--- a/parent/bdd/src/main/java/net/joala/bdd/reference/Reference.java
+++ b/parent/bdd/src/main/java/net/joala/bdd/reference/Reference.java
@@ -96,4 +96,25 @@ public interface Reference<T> {
    */
   @Nullable
   <P> P getProperty(@Nonnull String key, @Nonnull Class<P> clazz);
+
+  /**
+   * <p>
+   * Checks, whether a property with the given key is set.
+   * </p>
+   *
+   * @param key the name of the property
+   * @return <code>true</code> if the property is set, otherwise <code>false</code>
+   */
+  boolean hasProperty(@Nonnull String key);
+
+  /**
+   * Removes the property with the given key if it exists, otherwise does nothing.
+   *
+   * @param key the name of the property
+   * @param expectedClass the type of the property value to cast it to
+   * @param <P> the type of the proeprty value
+   * @return the property value if it was set, otherwise <code>null</code>.
+   */
+  @Nullable
+  <P> P removeProperty(@Nonnull String key, @Nonnull Class<P> expectedClass);
 }

--- a/parent/bdd/src/main/java/net/joala/bdd/reference/ReferenceImpl.java
+++ b/parent/bdd/src/main/java/net/joala/bdd/reference/ReferenceImpl.java
@@ -99,6 +99,25 @@ public class ReferenceImpl<T> implements Reference<T> {
   }
 
   @Override
+  public boolean hasProperty(@Nonnull String key) {
+    checkNotNull(key, "Property key must not be null.");
+    return properties.containsKey(key);
+  }
+
+  @Override
+  @Nullable
+  public <P> P removeProperty(@Nonnull String key, @Nonnull Class<P> expectedClass) {
+    checkNotNull(key, "Property key must not be null.");
+    checkNotNull(expectedClass, "Expected class must not be null.");
+
+    Object propertyValue = properties.remove(key);
+    if (propertyValue == null) {
+      return null;
+    }
+    return expectedClass.cast(propertyValue);
+  }
+
+  @Override
   public String toString() {
     return Objects.toStringHelper(this)
             .add("value", value)

--- a/parent/bdd/src/test/java/net/joala/bdd/reference/ReferenceImplTest.java
+++ b/parent/bdd/src/test/java/net/joala/bdd/reference/ReferenceImplTest.java
@@ -24,8 +24,11 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * <p>
@@ -103,4 +106,53 @@ public class ReferenceImplTest {
     reference.setProperty(null, "value");
   }
 
+
+  @SuppressWarnings("ConstantConditions")
+  @Test(expected = NullPointerException.class)
+  public void should_fail_for_asking_a_null_key() throws Exception {
+    Reference<String> reference = new ReferenceImpl<String>();
+    reference.hasProperty(null);
+  }
+
+  @Test
+  public void should_acknowledge_existing_key() {
+    Reference<String> reference = new ReferenceImpl<String>();
+    reference.setProperty("foo", "bar");
+    assertTrue("Expected \"foo\" to be there.", reference.hasProperty("foo"));
+  }
+
+  @Test
+  public void should_deny_existence_of_property() {
+    Reference<String> reference = new ReferenceImpl<String>();
+    assertFalse("\"foo\" must not be set.", reference.hasProperty("foo"));
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  @Test(expected = NullPointerException.class)
+  public void should_fail_for_removing_property_with_key_null() {
+    Reference<String> reference = new ReferenceImpl<String>();
+    reference.removeProperty(null, String.class);
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  @Test(expected = NullPointerException.class)
+  public void should_fail_for_removing_property_with_expected_class_null() {
+    Reference<String> reference = new ReferenceImpl<String>();
+    reference.removeProperty("foo", null);
+  }
+
+  @Test
+  public void should_remove_nothing_without_an_error() {
+    Reference<String> reference = new ReferenceImpl<String>();
+    assertNull("\"foo\" must not be set.", reference.removeProperty("foo", String.class));
+    assertTrue("\"foo\" must not be set anymore.", !reference.hasProperty("foo"));
+  }
+
+  @Test
+  public void should_remove_foo() {
+    Reference<String> reference = new ReferenceImpl<String>();
+    reference.setProperty("foo", "bar");
+    assertEquals("\"foo\" must be set to \"bar\".", "bar", reference.removeProperty("foo", String.class));
+    assertTrue("\"foo\" must not be set anymore.", !reference.hasProperty("foo"));
+  }
 }


### PR DESCRIPTION
Is there a reason why Reference does not provide methods for removing and chacking properties?

If not, please accept this pull request.

Tobias
