### PR TITLE
CMS-22707: Support Character Escape Sequences in Test Steps

### DIFF
--- a/parent/bdd/src/test/java/net/joala/bdd/aop/JUnitAopStepsLoggerTest.java
+++ b/parent/bdd/src/test/java/net/joala/bdd/aop/JUnitAopStepsLoggerTest.java
@@ -222,6 +222,20 @@ public class JUnitAopStepsLoggerTest {
     assertMessagesContains("given this is a step with a fake placeholder $42");
   }
 
+  @Test
+  public void testCharacterEscapes() throws Exception {
+    assumeThat(JUnitAopStepsLoggerTestAppender.getEvents().size(), Matchers.equalTo(0));
+    _.given_this_step$x27s_name_uses_many$x2c_many_$u0022escape_sequences$x22();
+    assertMessagesContains("given this step's name uses many, many \"escape sequences\"");
+  }
+
+  @Test
+  public void testCharacterEscapesAndPlaceholder() throws Exception {
+    assumeThat(JUnitAopStepsLoggerTestAppender.getEvents().size(), Matchers.equalTo(0));
+    _.given_this_is_a_step_with_an_escaped_character_$u272A_and_a_placeholder_$0("param");
+    assertMessagesContains("given this is a step with an escaped character ✪ and a placeholder \"param\"");
+  }
+
   @Named
   @Singleton
   public static class Steps {
@@ -267,6 +281,13 @@ public class JUnitAopStepsLoggerTest {
     }
 
     public void given_this_is_a_step_with_a_fake_placeholder_$42() {
+    }
+
+    public void given_this_step$x27s_name_uses_many$x2c_many_$u0022escape_sequences$x22() {
+    }
+
+    @SuppressWarnings("UnusedParameters")
+    public void given_this_is_a_step_with_an_escaped_character_$u272A_and_a_placeholder_$0(final String str) {
     }
   }
 


### PR DESCRIPTION
Test step method names can now contain escape sequences for arbitrary Unicode characters. For codes 0 - 255, use `$x` followed by exactly two hexadecimal digits (upper and lower case characters work), for any 2-byte Unicode character, use `$u` followed by four hex digits.
Typical examples: apostrophe, double-quote and comma:

    when_the_object$x27s_properties_are_set // when the object's properties are set
    when_the_value_is_$x22unknown$x22       // when the value is "unknown"
    then_click_A$x2c_B_or_C                 // then click A, B or C

Four-digit Unicode characters are less frequent, but may be useful, too:

    when_the_asterisk_$x22$u272A$x22_is_shown // when the asterisk "✪" is shown

Note that all "letter" and "currency" Unicode characters can be used in Java identifiers as-is, but may result in an inspection warning in IDEA.

    when_a_Tröt_for_2_€_is_displayed        // when a Tröt for 2 € is displayed

Implementation
--------------
Replaced the loop iterating single characters by a RegEx pattern matcher. Unfortunately, Joala is still limited to Java 8, so no Matcher#replaceAll(Function) and no Matcher#appendReplacement()/#appendTail().
But keeping track on the match position (pos) and
appending the text between matches is not that hard with Java 8 API either.