### PR TITLE
Dependency Updates (Focus: Logback; CVE-2023-6378)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.4.1</version>
         </plugin>
         <!-- see http://code.google.com/p/sortpom/ -->
         <!-- To start: mvn com.google.code.sortpom:maven-sortpom-plugin:sort -->
@@ -223,37 +223,37 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.3.1</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.11.0</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.6.0</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.1.1</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
           <version>3.4.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.13.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.8.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.1.3</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.5.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.1.3</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.10.0</version>
           <configuration>
             <doclint>none</doclint>
           </configuration>
@@ -261,7 +261,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.2</version>
           <configuration>
             <skipIfEmpty>true</skipIfEmpty>
             <archive>
@@ -284,12 +284,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.4.5</version>
+          <version>3.7.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.1.1</version>
           <configuration>
             <arguments>-Psonatype-oss-release -Dgpg.passphrase=${gpg.passphrase}</arguments>
             <autoVersionSubmodules>true</autoVersionSubmodules>
@@ -314,7 +314,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.12.1</version>
+          <version>3.20.0</version>
           <configuration>
             <generateSitemap>true</generateSitemap>
             <skipDeploy>true</skipDeploy>
@@ -356,12 +356,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.3.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.5.0</version>
           <configuration>
             <junitArtifactName>junit:junit</junitArtifactName>
             <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>

--- a/thirdparty-bom/pom.xml
+++ b/thirdparty-bom/pom.xml
@@ -32,7 +32,7 @@
   <properties>
     <aspectjweaver.version>1.9.20.1</aspectjweaver.version>
     <commons.lang3.version>3.13.0</commons.lang3.version>
-    <guava.version>32.1.2-jre</guava.version>
+    <guava.version>33.3.0-jre</guava.version>
     <jakarta.inject.version>2.0.1</jakarta.inject.version>
     <hamcrest.version>1.3</hamcrest.version>
     <httpclient.version>4.5.14</httpclient.version>

--- a/thirdparty-bom/pom.xml
+++ b/thirdparty-bom/pom.xml
@@ -31,7 +31,7 @@
   <description>Joala Bill of Materials for Thirdparty artifacts.</description>
   <properties>
     <aspectjweaver.version>1.9.20.1</aspectjweaver.version>
-    <commons.lang3.version>3.13.0</commons.lang3.version>
+    <commons.lang3.version>3.17.0</commons.lang3.version>
     <guava.version>33.3.0-jre</guava.version>
     <jakarta.inject.version>2.0.1</jakarta.inject.version>
     <hamcrest.version>1.3</hamcrest.version>

--- a/thirdparty-bom/pom.xml
+++ b/thirdparty-bom/pom.xml
@@ -41,7 +41,7 @@
     <junit.version>4.13.2</junit.version>
     <slf4j.version>2.0.16</slf4j.version>
     <spring.version>6.0.12</spring.version>
-    <commons-text.version>1.10.0</commons-text.version>
+    <commons-text.version>1.12.0</commons-text.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/thirdparty-bom/pom.xml
+++ b/thirdparty-bom/pom.xml
@@ -39,7 +39,7 @@
     <httpcore.version>4.4.16</httpcore.version>
     <jsr305.version>3.0.2</jsr305.version>
     <junit.version>4.13.2</junit.version>
-    <slf4j.version>2.0.9</slf4j.version>
+    <slf4j.version>2.0.16</slf4j.version>
     <spring.version>6.0.12</spring.version>
     <commons-text.version>1.10.0</commons-text.version>
   </properties>

--- a/thirdparty-bom/pom.xml
+++ b/thirdparty-bom/pom.xml
@@ -40,7 +40,7 @@
     <jsr305.version>3.0.2</jsr305.version>
     <junit.version>4.13.2</junit.version>
     <slf4j.version>2.0.16</slf4j.version>
-    <spring.version>6.0.12</spring.version>
+    <spring.version>6.1.12</spring.version>
     <commons-text.version>1.12.0</commons-text.version>
   </properties>
   <dependencyManagement>

--- a/thirdparty-bom/pom.xml
+++ b/thirdparty-bom/pom.xml
@@ -30,7 +30,7 @@
   <name>Joala 3rd-party BOM</name>
   <description>Joala Bill of Materials for Thirdparty artifacts.</description>
   <properties>
-    <aspectjweaver.version>1.9.20.1</aspectjweaver.version>
+    <aspectjweaver.version>1.9.22</aspectjweaver.version>
     <commons.lang3.version>3.17.0</commons.lang3.version>
     <guava.version>33.3.0-jre</guava.version>
     <jakarta.inject.version>2.0.1</jakarta.inject.version>

--- a/thirdparty-test-bom/pom.xml
+++ b/thirdparty-test-bom/pom.xml
@@ -39,10 +39,10 @@
     <jakarta.inject.version>2.0.1</jakarta.inject.version>
     <logback.version>1.5.8</logback.version>
     <powermock.version>2.0.9</powermock.version>
-    <mockito.version>5.5.0</mockito.version>
+    <mockito.version>5.13.0</mockito.version>
     <springockito.version>1.0.9</springockito.version>
     <objenesis.version>3.3</objenesis.version>
-    <byte-buddy-agent.version>1.14.6</byte-buddy-agent.version> <!-- keep in sync with mockito -->
+    <byte-buddy-agent.version>1.15.0</byte-buddy-agent.version> <!-- keep in sync with mockito -->
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/thirdparty-test-bom/pom.xml
+++ b/thirdparty-test-bom/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <spring.version>6.0.12</spring.version>
     <jakarta.inject.version>2.0.1</jakarta.inject.version>
-    <logback.version>1.4.11</logback.version>
+    <logback.version>1.5.8</logback.version>
     <powermock.version>2.0.9</powermock.version>
     <mockito.version>5.5.0</mockito.version>
     <springockito.version>1.0.9</springockito.version>

--- a/thirdparty-test-bom/pom.xml
+++ b/thirdparty-test-bom/pom.xml
@@ -35,7 +35,7 @@
   ]]></description>
 
   <properties>
-    <spring.version>6.0.12</spring.version>
+    <spring.version>6.1.12</spring.version>
     <jakarta.inject.version>2.0.1</jakarta.inject.version>
     <logback.version>1.5.8</logback.version>
     <powermock.version>2.0.9</powermock.version>


### PR DESCRIPTION
A bunch of dependency updates, originally triggered by vulnerability for Logback (CVE-2023-6378).

Also, updated especially related Slf4j version, as well as all other (available) dependency updates, to stay up to date.